### PR TITLE
boards: arduino: add pull-ups to all stm32 UART RX lines

### DIFF
--- a/boards/arduino/giga_r1/arduino_giga_r1_stm32h747xx_m7.dts
+++ b/boards/arduino/giga_r1/arduino_giga_r1_stm32h747xx_m7.dts
@@ -76,6 +76,10 @@
 	clock-frequency = <DT_FREQ_M(480)>;
 };
 
+&usart1_rx_pb7 {
+	bias-pull-up;
+};
+
 &usart1 {
 	status = "okay";
 	pinctrl-0 = <&usart1_tx_pa9 &usart1_rx_pb7>;
@@ -83,11 +87,19 @@
 	current-speed = <115200>;
 };
 
+&usart6_rx_pc7 {
+	bias-pull-up;
+};
+
 &usart6 {
 	status = "disabled";
 	pinctrl-0 = <&usart6_tx_pg14 &usart6_rx_pc7>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
+};
+
+&uart4_rx_pi9 {
+	bias-pull-up;
 };
 
 &uart4 {

--- a/boards/arduino/opta/arduino_opta-common.dtsi
+++ b/boards/arduino/opta/arduino_opta-common.dtsi
@@ -104,6 +104,16 @@
 	};
 };
 
+&usart6_rx_pg9 {
+	bias-pull-up;
+};
+
+&usart6 {
+	pinctrl-0 = <&usart6_tx_pg14 &usart6_rx_pg9>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+};
+
 &adc1 {
 	pinctrl-0 = <&adc1_inp0_pa0_c &adc1_inp6_pf12>;
 	pinctrl-names = "default";

--- a/boards/arduino/portenta_h7/arduino_portenta_h7-common.dtsi
+++ b/boards/arduino/portenta_h7/arduino_portenta_h7-common.dtsi
@@ -49,6 +49,10 @@
 };
 
 /* UART0 in datasheet */
+&uart4_rx_pi9 {
+	bias-pull-up;
+};
+
 &uart4 {
 	pinctrl-0 = <&uart4_tx_pa0 &uart4_rx_pi9>;
 	pinctrl-names = "default";
@@ -56,6 +60,10 @@
 };
 
 /* UART1 in datasheet */
+&usart1_rx_pa10 {
+	bias-pull-up;
+};
+
 &usart1 {
 	pinctrl-0 = <&usart1_tx_pa9 &usart1_rx_pa10>;
 	pinctrl-names = "default";
@@ -63,6 +71,10 @@
 };
 
 /* UART2 in datasheet */
+&usart6_rx_pg9 {
+	bias-pull-up;
+};
+
 &usart6 {
 	pinctrl-0 = <&usart6_tx_pg14 &usart6_rx_pg9>;
 	pinctrl-names = "default";
@@ -70,6 +82,10 @@
 };
 
 /* UART3 in datasheet */
+&uart8_rx_pj9 {
+	bias-pull-up;
+};
+
 &uart8 {
 	pinctrl-0 = <&uart8_tx_pj8 &uart8_rx_pj9>;
 	pinctrl-names = "default";

--- a/boards/arduino/uno_q/arduino_uno_q-common.dtsi
+++ b/boards/arduino/uno_q/arduino_uno_q-common.dtsi
@@ -98,12 +98,20 @@ stm32_lp_tick_source: &lptim1 {
 	status = "okay";
 };
 
+&lpuart1_rx_pg8 {
+	bias-pull-up;
+};
+
 &lpuart1 {
 	pinctrl-0 = <&lpuart1_tx_pg7 &lpuart1_rx_pg8
-				&lpuart1_rts_pg6 &lpuart1_cts_pg5>;
+		     &lpuart1_rts_pg6 &lpuart1_cts_pg5>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
 	status = "okay";
+};
+
+&usart1_rx_pb7 {
+	bias-pull-up;
 };
 
 &usart1 {


### PR DESCRIPTION
Add pull-up configuration to the RX lines of all UART peripherals to avoid floating inputs when no connection is made to the UART pins.