### PR TITLE
Boards: added header include for Nicla Vision dts.

### DIFF
--- a/boards/arduino/nicla_vision/arduino_nicla_vision_stm32h747xx_m7.dts
+++ b/boards/arduino/nicla_vision/arduino_nicla_vision_stm32h747xx_m7.dts
@@ -26,6 +26,14 @@
 		zephyr,camera = &dcmi;
 	};
 
+	ext_memory: memory@90000000 {
+		compatible = "zephyr,memory-region";
+		reg = <0x90000000 DT_SIZE_M(16)>; /* max addressable area */
+		zephyr,memory-region = "EXTMEM";
+		/* The ATTR_MPU_EXTMEM attribut causing a MPU FAULT */
+		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_IO) )>;
+	};
+
 	aliases {
 		led0 = &red_led;
 		led1 = &green_led;

--- a/boards/arduino/nicla_vision/arduino_nicla_vision_stm32h747xx_m7.dts
+++ b/boards/arduino/nicla_vision/arduino_nicla_vision_stm32h747xx_m7.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <st/h7/stm32h747Xi_m7.dtsi>
 #include <st/h7/stm32h747a(g-i)ix-pinctrl.dtsi>
+#include <st/h7/stm32h747xihx-pinctrl.dtsi>
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 #include "arduino_nicla_vision.dtsi"
 
@@ -28,6 +29,7 @@
 	aliases {
 		led0 = &red_led;
 		led1 = &green_led;
+		led2 = &blue_led;
 	};
 
 	otghs_ulpi_phy: otghs_ulpis_phy {


### PR DESCRIPTION
To allow resolving pinmux defines in the Nicla Vision app overlay "arduino_nicla_vision_stm32h747xx_m7.dts" needs to also include "#include <st/h7/stm32h747xihx-pinctrl.dtsi>".