### PR TITLE
stm32_h7: use the correct macro to set VOS0

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -260,7 +260,7 @@ static int32_t prepare_regulator_voltage_scale(void)
 {
 	/* Make sure to put the CPU in highest Voltage scale during clock configuration */
 	/* Highest voltage is SCALE0 */
-	LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE0);
+	__HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE0);
 #if defined(CONFIG_SOC_SERIES_STM32H7RSX)
 	while (LL_PWR_IsActiveFlag_VOSRDY() == 0) {
 #else


### PR DESCRIPTION
This PR uses the correct macro that actually set VOS0 (thanks to @pillo79  that got the bottom of the problem discovering that this is a bug in the STM zephyr driver). A bug report that explains the problem can be found here: https://github.com/zephyrproject-rtos/zephyr/issues/104536.
This PR supersedes this one https://github.com/arduino/ArduinoCore-zephyr/pull/359 that was aimed to solve the same problem at the arduino core level.
(@andreagilardoni in case you prefer to use this one)