### PR TITLE
can: add configuration for Arduino Uno Q, Portenta H7 and Portenta C33

### DIFF
--- a/boards/arduino/portenta_c33/arduino_portenta_c33-pinctrl.dtsi
+++ b/boards/arduino/portenta_c33/arduino_portenta_c33-pinctrl.dtsi
@@ -167,6 +167,14 @@
 		};
 	};
 
+	canfd0_default: canfd0_default {
+		group1 {
+			/* CAN0 RX: P2_2, CAN0 TX: P2_3 */
+			psels = <RA_PSEL(RA_PSEL_CANFD, 2, 2)>,
+				<RA_PSEL(RA_PSEL_CANFD, 2, 3)>;
+		};
+	};
+
 	pwm7_default: pwm7_default {
 		group1 {
 			psels = <RA_PSEL(RA_PSEL_GPT1, 3, 3)>;

--- a/boards/arduino/portenta_c33/arduino_portenta_c33.dts
+++ b/boards/arduino/portenta_c33/arduino_portenta_c33.dts
@@ -26,6 +26,7 @@
 		zephyr,shell-uart = &uart9;
 		zephyr,entropy = &trng;
 		zephyr,bt-hci = &bt_hci_uart;
+		zephyr,canbus = &canfd0;
 	};
 
 	leds {
@@ -400,6 +401,23 @@
 		clock-frequency = <DT_FREQ_M(25)>;
 		#clock-cells = <1>;
 		pwms = <&pwm6 1 PWM_KHZ(25000) PWM_POLARITY_NORMAL>;
+	};
+};
+
+&canfdclk {
+	clocks = <&pll>;
+	div = <5>;
+};
+
+&canfd_global {
+	canfd0 {
+		pinctrl-0 = <&canfd0_default>;
+		pinctrl-names = "default";
+		rx-max-filters = <16>;
+
+		can-transceiver {
+			max-bitrate = <5000000>;
+		};
 	};
 };
 

--- a/boards/arduino/portenta_h7/arduino_portenta_h7_stm32h747xx_m7.dts
+++ b/boards/arduino/portenta_h7/arduino_portenta_h7_stm32h747xx_m7.dts
@@ -20,6 +20,7 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,bt-hci = &bt_hci_uart;
+		zephyr,canbus = &fdcan1;
 	};
 
 	oscen: oscen {

--- a/boards/arduino/uno_q/arduino_uno_q.dts
+++ b/boards/arduino/uno_q/arduino_uno_q.dts
@@ -19,6 +19,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,canbus = &fdcan1;
 	};
 
 	aliases {

--- a/boards/arduino/uno_q/arduino_uno_q_stm32u585xx_ns.dts
+++ b/boards/arduino/uno_q/arduino_uno_q_stm32u585xx_ns.dts
@@ -18,6 +18,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_ns_partition;
+		zephyr,canbus = &fdcan1;
 	};
 
 	aliases {

--- a/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi
@@ -282,6 +282,37 @@
 			compatible = "renesas,ra-sce9-rng";
 			status = "disabled";
 		};
+
+		canfd_global: canfd_global@400b0000 {
+			compatible = "renesas,ra-canfd-global";
+			interrupts = <39 1>, <40 1>;
+			interrupt-names = "rxf", "glerr";
+			clocks = <&pclkb 0 0>, <&pclka 0 0>;
+			clock-names = "opclk", "ramclk";
+			dll-max-freq = <DT_FREQ_M(40)>;
+			reg = <0x400b0000 0x2000>;
+			status = "disabled";
+
+			canfd0: canfd0 {
+				compatible = "renesas,ra-canfd";
+				channel = <0>;
+				interrupts = <43 12>, <44 12>, <45 12>;
+				interrupt-names = "err", "tx", "rx";
+				clocks = <&canfdclk MSTPC 27>;
+				clock-names = "dllclk";
+				status = "disabled";
+			};
+
+			canfd1: canfd1 {
+				compatible = "renesas,ra-canfd";
+				channel = <1>;
+				interrupts = <46 12>, <47 12>, <48 12>;
+				interrupt-names = "err", "tx", "rx";
+				clocks = <&canfdclk MSTPC 26>;
+				clock-names = "dllclk";
+				status = "disabled";
+			};
+		};
 	};
 
 	clocks: clocks {


### PR DESCRIPTION
**drivers: can: add configuration for Arduino Uno Q, Portenta H7 and Portenta C33**

This includes:
- Board DTS configuration for CAN support on the supported boards
- Update of Renesas dtsi (r7fa6m5xh.dtsi) to add the missing `canfd_global` node and align with existing RA6 conventions (e.g. r7fa6e2bx.dtsi)


