### PR TITLE
stm32_h7: mitigate power peak during VOS0 activation 

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -266,6 +266,10 @@ static int32_t prepare_regulator_voltage_scale(void)
 #else
 	while (LL_PWR_IsActiveFlag_VOS() == 0) {
 #endif
+		/* arch_nop() prevents a tight polling loop from causing a high
+		 * power consumption peak that can hang the board during VOS0 activation.
+		 */
+		arch_nop();
 	}
 
 	return 0;


### PR DESCRIPTION
Add a NOP to mitigate high transient power consumption during the tight polling loop. Without this, the sudden current peak during the VOS0 transition combined with concurrent power-hungry peripheral startups (e.g., Wi-Fi firmware loading) can cause some boards to hang on boot.