### PR TITLE
video: stm32_dcmi:  DMA Error recovery

### DIFF
--- a/drivers/video/video_stm32_dcmi.c
+++ b/drivers/video/video_stm32_dcmi.c
@@ -55,9 +55,31 @@ struct video_stm32_dcmi_config {
 	const struct stream dma;
 };
 
+static void stm32_dcmi_process_dma_error(DCMI_HandleTypeDef *hdcmi)
+{
+	struct video_stm32_dcmi_data *dev_data =
+		CONTAINER_OF(hdcmi, struct video_stm32_dcmi_data, hdcmi);
+
+	LOG_DBG("Restart DMA after Error!");
+
+	/* Lets try to recover by stopping and restart */
+	if (HAL_DCMI_Stop(&dev_data->hdcmi) != HAL_OK) {
+		LOG_WRN("HAL_DCMI_Stop FAILED!");
+		return;
+	}
+
+	if (HAL_DCMI_Start_DMA(&dev_data->hdcmi,
+			       DCMI_MODE_CONTINUOUS,
+			       (uint32_t)dev_data->vbuf->buffer,
+			       dev_data->vbuf->bytesused / 4) != HAL_OK) {
+		LOG_WRN("Continuous: HAL_DCMI_Start_DMA FAILED!");
+		return;
+	}
+}
+
 void HAL_DCMI_ErrorCallback(DCMI_HandleTypeDef *hdcmi)
 {
-	LOG_WRN("%s", __func__);
+	stm32_dcmi_process_dma_error(hdcmi);
 }
 
 void HAL_DCMI_FrameEventCallback(DCMI_HandleTypeDef *hdcmi)
@@ -96,17 +118,10 @@ static void dcmi_dma_callback(const struct device *dev, void *arg, uint32_t chan
 	DMA_HandleTypeDef *hdma = arg;
 
 	ARG_UNUSED(dev);
-
-	if (status < 0) {
-		LOG_ERR("DMA callback error with channel %d.", channel);
-	}
+	ARG_UNUSED(channel);
+	ARG_UNUSED(status);
 
 	HAL_DMA_IRQHandler(hdma);
-}
-
-void HAL_DMA_ErrorCallback(DMA_HandleTypeDef *hdma)
-{
-	LOG_WRN("%s", __func__);
 }
 
 #if defined(CONFIG_SOC_SERIES_STM32U585X)


### PR DESCRIPTION
On several boards, such as the Arduino Giga and
Portenta H7, they are often times setup with their camera buffers and potentially video buffers in
SDRam.  This can lead to a significant number of
DMA errors, which currently stops the camera from
returning any additional frames.

This is a cherry-picked commit from the main zephyr repository, that was pulled in a little after when the 4.2 version was released.  

Not sure of your timeframe.  If you are switching to the 4.4 branch soon, then this PR may not be important, but the switch is still tentative and unsure of time frame, I know this helped on the GIGA a lot.  On H7 it still has problems with it's main buffer it hands off to camera, it errored almost everytime.  