### PR TITLE
sensors: stm32: stm32_temp handle adc defered-init

### DIFF
--- a/drivers/sensor/st/stm32_temp/stm32_temp.c
+++ b/drivers/sensor/st/stm32_temp/stm32_temp.c
@@ -267,8 +267,10 @@ static int stm32_temp_init(const struct device *dev)
 	k_mutex_init(&data->mutex);
 
 	if (!device_is_ready(data->adc)) {
-		LOG_ERR("Device %s is not ready", data->adc->name);
-		return -ENODEV;
+		if (device_init(data->adc) < 0) {
+			LOG_ERR("Device %s is not ready", data->adc->name);
+			return -ENODEV;
+		}
 	}
 
 	*asp = (struct adc_sequence){

--- a/drivers/sensor/st/stm32_vref/stm32_vref.c
+++ b/drivers/sensor/st/stm32_vref/stm32_vref.c
@@ -129,8 +129,10 @@ static int stm32_vref_init(const struct device *dev)
 	k_mutex_init(&data->mutex);
 
 	if (!device_is_ready(data->adc)) {
-		LOG_ERR("Device %s is not ready", data->adc->name);
-		return -ENODEV;
+		if (device_init(data->adc) < 0) {
+			LOG_ERR("Device %s is not ready", data->adc->name);
+			return -ENODEV;
+		}
 	}
 
 	*asp = (struct adc_sequence){


### PR DESCRIPTION
on stm32_temp.c and stm32_vref.c  If we find that
the adc driver is not ready try doing a device_init on it as it may have been configured as
defered-init