### PR TITLE
[Backport] drivers: flash_stm32h7: Fix REAL_FLASH_SIZE_KB size

### DIFF
--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -37,6 +37,7 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 /* No information in documentation about that. */
 #define STM32H7_FLASH_OPT_TIMEOUT_MS 800
 
+#if DT_NODE_HAS_PROP(DT_INST(0, st_stm32_nv_flash), bank2_flash_size)
 #define STM32H7_M4_FLASH_SIZE DT_PROP_OR(DT_INST(0, st_stm32_nv_flash), bank2_flash_size, 0)
 #ifdef CONFIG_CPU_CORTEX_M4
 #if STM32H7_M4_FLASH_SIZE == 0
@@ -45,11 +46,10 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 #define REAL_FLASH_SIZE_KB (KB(STM32H7_M4_FLASH_SIZE * 2))
 #endif
 #else
-#if defined(DUAL_BANK)
 #define REAL_FLASH_SIZE_KB (DT_REG_SIZE(DT_INST(0, st_stm32_nv_flash)) * 2)
+#endif
 #else
 #define REAL_FLASH_SIZE_KB DT_REG_SIZE(DT_INST(0, st_stm32_nv_flash))
-#endif
 #endif
 #define SECTOR_PER_BANK ((REAL_FLASH_SIZE_KB / FLASH_SECTOR_SIZE) / 2)
 #if defined(DUAL_BANK)


### PR DESCRIPTION
For devices other than the stm32h745/747/755/757 that use dual-core cortex-M4/cortex-M7, do not multiply flash controller size by 2. Single-core stm32h7x devices define their flash-controllers dtsi as a single area, not two banks. Use the presence of the bank2-flash-size prop to determine if this is a dual-core stm3h7x or not.

This PR addresses the issue of board accidentally bricked when erasing the second bank of flash on stm32h747xx