### PR TITLE
boards: nxp: frdm_mcxn947: add ADC (A2-A5) and PWM (D3/D5/D6/D9/D12/D13) support for Arduino pins

### DIFF
--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947-pinctrl.dtsi
@@ -160,6 +160,44 @@
 		};
 	};
 
+	/*
+	 * Pin order here must match the order ctimer0_pwm entries appear in
+	 * the zephyr,user "pwms" property (state_pin_index_from_spec_index()
+	 * indexes into this group by per-device occurrence order, not by
+	 * channel number).
+	 *
+	 * CT0_MAT3 (D10) is intentionally not included: CTimer requires one
+	 * of its 4 match channels to be reserved internally as the period/
+	 * reset channel, so only 3 of MAT0-3 can be independent PWM pulse
+	 * outputs at once. D10 also carries SPI SS, so MAT0-2 (D9/D13/D12)
+	 * were kept instead.
+	 */
+	pinmux_ctimer0_pwm_arduino: pinmux_ctimer0_pwm_arduino {
+		group0 {
+			pinmux = <CT0_MAT0_PIO0_10>,  /* D9  MAT0 */
+				<CT0_MAT1_PIO0_25>,   /* D13 MAT1 */
+				<CT0_MAT2_PIO0_26>;   /* D12 MAT2 */
+			slew-rate = "fast";
+			drive-strength = "low";
+		};
+	};
+
+	pinmux_ctimer1_pwm_arduino: pinmux_ctimer1_pwm_arduino {
+		group0 {
+			pinmux = <CT1_MAT0_PIO1_2>;  /* D6 */
+			slew-rate = "fast";
+			drive-strength = "low";
+		};
+	};
+
+	pinmux_ctimer3_pwm_arduino: pinmux_ctimer3_pwm_arduino {
+		group0 {
+			pinmux = <CT3_MAT3_PIO1_21>;  /* D5 */
+			slew-rate = "fast";
+			drive-strength = "low";
+		};
+	};
+
 	pinmux_flexpwm1_pwm1: pinmux_flexpwm1_pwm1 {
 		group0 {
 			pinmux = <PWM1_A1_PIO2_4>,
@@ -287,6 +325,14 @@
 			slew-rate = "fast";
 			drive-strength = "low";
 			input-enable;
+		};
+	};
+
+	pinmux_sctimer_arduino: pinmux_sctimer_arduino {
+		group0 {
+			pinmux = <SCT0_OUT5_PIO1_23>;  /* D3 */
+			slew-rate = "fast";
+			drive-strength = "low";
 		};
 	};
 

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947-pinctrl.dtsi
@@ -7,12 +7,19 @@
 #include <nxp/mcx/MCXN947VDF-pinctrl.h>
 
 &pinctrl {
+	/*
+	 * FC1_P3 (P0_27, native PCS0 / D10) is deliberately excluded.
+	 * Classic Arduino SPI usage treats SS as a plain digitalWrite()-
+	 * controlled pin managed by the sketch, not something the SPI
+	 * peripheral drives automatically - keeping D10 off of LPSPI1's
+	 * pinctrl claim leaves it fully available as an ordinary GPIO/PWM
+	 * pin at all times, and matches that expectation.
+	 */
 	pinmux_flexcomm1_lpspi: pinmux_flexcomm1_lpspi {
 		group0 {
 			pinmux = <FC1_P0_PIO0_24>,
 				<FC1_P1_PIO0_25>,
-				<FC1_P2_PIO0_26>,
-				<FC1_P3_PIO0_27>;
+				<FC1_P2_PIO0_26>;
 			slew-rate = "fast";
 			drive-strength = "low";
 			input-enable;

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947-pinctrl.dtsi
@@ -233,6 +233,18 @@
 		};
 	};
 
+	pinmux_lpadc0_arduino: pinmux_lpadc0_arduino {
+		group0 {
+			pinmux = <ADC0_B14_PIO0_14>,  /* A2 = P0_14 */
+				<ADC0_A14_PIO0_22>,   /* A3 = P0_22 */
+				<ADC0_B15_PIO0_15>,   /* A4 = P0_15 */
+				<ADC0_A15_PIO0_23>;   /* A5 = P0_23 */
+			slew-rate = "fast";
+			drive-strength = "low";
+			input-enable;
+		};
+	};
+
 	pinmux_lpcmp0: pinmux_lpcmp0 {
 		group0 {
 			pinmux = <CMP0_IN0_PIO1_0>;

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
@@ -10,6 +10,7 @@
 #include <zephyr/dt-bindings/gpio/dvp-20pin-connector.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {
 	aliases{
@@ -293,6 +294,55 @@ nxp_8080_touch_panel_i2c: &flexcomm2_lpi2c2 {
 	};
 };
 
+/*
+ * CTimer match outputs are re-purposed as PWM outputs for analogWrite(),
+ * sharing the pin with digital-pin-gpios via the "arduino" pinctrl state.
+ * These CTimer instances are declared as plain counters ("nxp,lpc-ctimer")
+ * at the SoC level; overriding to "nxp,ctimer-pwm" exposes the same
+ * hardware through the PWM API instead.
+ *
+ * CT0_MAT0 (D9), CT0_MAT1 (D13) and CT0_MAT2 (D12) belong to the same
+ * ctimer0 instance (CT0_MAT3/D10 is deliberately not used - CTimer needs
+ * one of its 4 match channels reserved internally as the period/reset
+ * channel, so only 3 of MAT0-3 can be independent PWM outputs at once).
+ * D12/D13 also carry the SPI MISO/SCK alternate function
+ * (flexcomm1_lpspi1) - using analogWrite() on those pins reclaims the pin
+ * mux from SPI and is not restored automatically, so SPI and PWM on those
+ * specific pins are mutually exclusive within a single sketch.
+ */
+ctimer0_pwm: &ctimer0 {
+	compatible = "nxp,ctimer-pwm";
+	status = "okay";
+	zephyr,deferred-init;
+	prescaler = <0>;
+	pinctrl-0 = <&pinmux_ctimer0_pwm_arduino>;
+	pinctrl-1 = <&pinmux_ctimer0_pwm_arduino>;
+	pinctrl-names = "default", "arduino";
+	#pwm-cells = <3>;
+};
+
+ctimer1_pwm: &ctimer1 {
+	compatible = "nxp,ctimer-pwm";
+	status = "okay";
+	zephyr,deferred-init;
+	prescaler = <0>;
+	pinctrl-0 = <&pinmux_ctimer1_pwm_arduino>;
+	pinctrl-1 = <&pinmux_ctimer1_pwm_arduino>;
+	pinctrl-names = "default", "arduino";
+	#pwm-cells = <3>;
+};
+
+ctimer3_pwm: &ctimer3 {
+	compatible = "nxp,ctimer-pwm";
+	status = "okay";
+	zephyr,deferred-init;
+	prescaler = <0>;
+	pinctrl-0 = <&pinmux_ctimer3_pwm_arduino>;
+	pinctrl-1 = <&pinmux_ctimer3_pwm_arduino>;
+	pinctrl-names = "default", "arduino";
+	#pwm-cells = <3>;
+};
+
 zephyr_mipi_dbi_parallel: &flexio0_lcd {
 	/* DMA channels 0, muxed to FlexIO TX */
 	dmas = <&edma0 0 61>;
@@ -326,7 +376,11 @@ zephyr_mipi_dbi_parallel: &flexio0_lcd {
 
 &sc_timer {
 	pinctrl-0 = <&pinmux_sctimer>;
-	pinctrl-names = "default";
+	/* SCT0_OUT5 (D3) reuses the existing sc_timer instance (SCT0_OUT0
+	 * is unrelated, reserved for onboard use). */
+	pinctrl-1 = <&pinmux_sctimer_arduino>;
+	pinctrl-names = "default", "arduino";
+	zephyr,deferred-init;
 };
 
 /*

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
@@ -250,8 +250,10 @@ nxp_8080_touch_panel_i2c: &flexcomm2_lpi2c2 {
 	pinctrl-1 = <&pinmux_lpadc0_arduino>;
 	pinctrl-names = "default", "arduino";
 	zephyr,deferred-init;
-	/* Alt1: use VREFH (measured 3.3V on this board) instead of the SoC
-	 * default Alt2 (internal VREF regulator, capped at 2.1V). */
+	/*
+	 * Alt1: use VREFH (measured 3.3V on this board) instead of the SoC
+	 * default Alt2 (internal VREF regulator, capped at 2.1V).
+	 */
 	voltage-ref = <0>;
 	#address-cells = <1>;
 	#size-cells = <0>;
@@ -376,8 +378,10 @@ zephyr_mipi_dbi_parallel: &flexio0_lcd {
 
 &sc_timer {
 	pinctrl-0 = <&pinmux_sctimer>;
-	/* SCT0_OUT5 (D3) reuses the existing sc_timer instance (SCT0_OUT0
-	 * is unrelated, reserved for onboard use). */
+	/*
+	 * SCT0_OUT5 (D3) reuses the existing sc_timer instance (SCT0_OUT0
+	 * is unrelated, reserved for onboard use).
+	 */
 	pinctrl-1 = <&pinmux_sctimer_arduino>;
 	pinctrl-names = "default", "arduino";
 	zephyr,deferred-init;

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
@@ -8,6 +8,8 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/gpio/dvp-20pin-connector.h>
+#include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 
 / {
 	aliases{
@@ -244,7 +246,51 @@ nxp_8080_touch_panel_i2c: &flexcomm2_lpi2c2 {
 
 &lpadc0 {
 	pinctrl-0 = <&pinmux_lpadc0>;
-	pinctrl-names = "default";
+	pinctrl-1 = <&pinmux_lpadc0_arduino>;
+	pinctrl-names = "default", "arduino";
+	zephyr,deferred-init;
+	/* Alt1: use VREFH (measured 3.3V on this board) instead of the SoC
+	 * default Alt2 (internal VREF regulator, capped at 2.1V). */
+	voltage-ref = <0>;
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,vref-mv = <3300>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <MCUX_LPADC_CH14B>;  /* A2 */
+	};
+	channel@3 {
+		reg = <3>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,vref-mv = <3300>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <MCUX_LPADC_CH14A>;  /* A3 */
+	};
+	channel@4 {
+		reg = <4>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,vref-mv = <3300>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <MCUX_LPADC_CH15B>;  /* A4 */
+	};
+	channel@5 {
+		reg = <5>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,vref-mv = <3300>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <MCUX_LPADC_CH15A>;  /* A5 */
+	};
 };
 
 zephyr_mipi_dbi_parallel: &flexio0_lcd {


### PR DESCRIPTION
## Summary

Adds Arduino header analog/PWM pin support for FRDM-MCXN947:

- **ADC (A2-A5)**: new `pinmux_lpadc0_arduino` pinctrl state and `lpadc0`
  channel nodes for P0_14/P0_22/P0_15/P0_23, switched to VREFH (3.3V)
  reference to match this board's wiring.
- **PWM (D3/D5/D6/D9/D12/D13)**: CTimer0/1/3 and SCTimer overrides to
  `nxp,ctimer-pwm`/`nxp,sctimer-pwm`, each with "default"/"arduino"
  pinctrl states for pins shared with `digital-pin-gpios`. D10
  (CT0_MAT3) is intentionally excluded - only 3 of ctimer0's 4 match
  channels can be independent PWM outputs, since one is always
  reserved internally as the period/reset channel.
- **SPI SS (D10)**: excluded from LPSPI1's pinctrl entirely, so it
  stays available as a plain GPIO/PWM pin - CS is meant to be
  sketch-controlled via `digitalWrite()`, matching classic Arduino SPI
  semantics rather than relying on native hardware CS.

All changes were verified on real hardware (logic analyzer for PWM
duty cycle / polarity, multimeter for ADC voltage, oscilloscope for
SPI CS timing).

Companion PR on the Arduino core side (wires up `analogRead`/
`analogWrite`/CS handling): arduino/ArduinoCore-zephyr#TBD

## Notes

- The polarity flags for PWM were determined empirically: CTimer
  ("nxp,ctimer-pwm") channels needed `PWM_POLARITY_INVERTED` to
  produce the correct duty cycle (confirmed as an exact 100%-
  complement measurement under `PWM_POLARITY_NORMAL`), while SCTimer
  ("nxp,sctimer-pwm") needed `PWM_POLARITY_NORMAL`.
- `lpadc0`/`ctimer0`/`ctimer1`/`ctimer3`/`sc_timer` are marked
  `zephyr,deferred-init` so the Arduino core's runtime pinctrl
  switching (`init_dev_apply_channel_pinctrl()`) can register them.