### PR TITLE
boards: arduino: portenta_c33: add mkr spi

### DIFF
--- a/boards/arduino/portenta_c33/arduino_mkr_connector.dtsi
+++ b/boards/arduino/portenta_c33/arduino_mkr_connector.dtsi
@@ -40,7 +40,4 @@ arduino_mkr_i2c: &iic0 {};
 
 arduino_mkr_serial: &uart9 {};
 
-/*
- * TODO: enable when SCI as SPI is supported
- * arduino_mkr_spi: &sci4 {};
- */
+arduino_mkr_spi: &sci4_spi {};

--- a/boards/arduino/portenta_c33/arduino_portenta_c33-pinctrl.dtsi
+++ b/boards/arduino/portenta_c33/arduino_portenta_c33-pinctrl.dtsi
@@ -187,6 +187,15 @@
 		};
 	};
 
+	sci4_spi_default: sci4_spi_default {
+		group1 {
+			/* MOSI(TXD4) SCK4 MISO(RXD4) */
+			psels = <RA_PSEL(RA_PSEL_SCI_4, 9, 0)>,
+				<RA_PSEL(RA_PSEL_SCI_4, 2, 4)>,
+				<RA_PSEL(RA_PSEL_SCI_4, 3, 15)>;
+		};
+	};
+
 	canfd0_default: canfd0_default {
 		group1 {
 			/* CAN0 RX: P2_2, CAN0 TX: P2_3 */

--- a/boards/arduino/portenta_c33/arduino_portenta_c33.dts
+++ b/boards/arduino/portenta_c33/arduino_portenta_c33.dts
@@ -71,6 +71,16 @@
 	};
 };
 
+&sci4 {
+	pinctrl-0 = <&sci4_spi_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	sci4_spi: spi {
+		status = "okay";
+	};
+};
+
 &sci8 {
 	pinctrl-0 = <&sci8_default>;
 	pinctrl-names = "default";


### PR DESCRIPTION
Configure SCI4 as the SPI controller for the Arduino MKR connector.